### PR TITLE
Hotfix for tests not running

### DIFF
--- a/app/client/components/DashboardForceCurve.js
+++ b/app/client/components/DashboardForceCurve.js
@@ -8,7 +8,7 @@
 import { AppElement, html, css } from './AppElement.js'
 import { customElement, property, state } from 'lit/decorators.js'
 import ChartDataLabels from 'chartjs-plugin-datalabels'
-import { Chart, Filler, Legend, LinearScale, LineController, LineElement, PointElement } from 'chart.js/auto'
+import { Chart, Filler, Legend, LinearScale, LineController, LineElement, PointElement } from 'chart.js'
 
 @customElement('dashboard-force-curve')
 export class DashboardForceCurve extends AppElement {

--- a/app/client/components/PerformanceDashboard.js
+++ b/app/client/components/PerformanceDashboard.js
@@ -7,7 +7,7 @@
 
 import { AppElement, html, css } from './AppElement.js'
 import { customElement, property, state } from 'lit/decorators.js'
-import './SettingsDialog'
+import './SettingsDialog.js'
 import { icon_settings } from '../lib/icons.js'
 import { DASHBOARD_METRICS } from '../store/dashboardMetrics.js'
 

--- a/app/client/lib/helper.js
+++ b/app/client/lib/helper.js
@@ -1,8 +1,5 @@
 'use strict'
 
-import { html } from 'lit'
-import '../components/DashboardMetric.js'
-
 /*
   Open Rowing Monitor, https://github.com/laberning/openrowingmonitor
 
@@ -60,15 +57,4 @@ export function formatNumber (value, decimalPlaces = 0) {
   if (value === undefined || value === null || value === Infinity || isNaN(value) || value === 0) { return '--' }
 
   return Math.round(value * decimal) / decimal
-}
-
-/**
-  * Helper function to create a simple metric tile
-  *
-  * @param {string | number} value The metric to show
-  * @param {string} unit The unit of the metric.
-  * @param {string | import('lit').TemplateResult<2>} icon The number of decimal places to round to (default: 0).
-*/
-export function simpleMetricFactory (value = '--', unit = '', icon = '') {
-  return html`<dashboard-metric .icon=${icon} .unit=${unit} .value=${value}></dashboard-metric>`
 }

--- a/app/client/store/dashboardMetrics.js
+++ b/app/client/store/dashboardMetrics.js
@@ -1,8 +1,9 @@
 import { html } from 'lit'
-import { simpleMetricFactory, formatDistance, formatNumber, secondsToPace } from '../lib/helper'
+import { formatDistance, formatNumber, secondsToPace } from '../lib/helper'
 import { icon_bolt, icon_clock, icon_fire, icon_heartbeat, icon_paddle, icon_route, icon_stopwatch, rower_icon } from '../lib/icons'
 import '../components/DashboardForceCurve.js'
 import '../components/DashboardActions.js'
+import '../components/DashboardMetric.js'
 import '../components/BatteryIcon.js'
 
 export const DASHBOARD_METRICS = {
@@ -67,4 +68,15 @@ export const DASHBOARD_METRICS = {
   forceCurve: { displayName: 'Force curve', size: 2, template: (metrics) => html`<dashboard-force-curve .value=${metrics.driveHandleForceCurve} style="grid-column: span 2"></dashboard-force-curve>` },
 
   actions: { displayName: 'Actions', size: 1, template: (_, config) => html`<dashboard-actions .config=${config}></dashboard-actions>` }
+}
+
+/**
+  * Helper function to create a simple metric tile
+  *
+  * @param {string | number} value The metric to show
+  * @param {string} unit The unit of the metric.
+  * @param {string | import('lit').TemplateResult<2>} icon The number of decimal places to round to (default: 0).
+*/
+function simpleMetricFactory (value = '--', unit = '', icon = '') {
+  return html`<dashboard-metric .icon=${icon} .unit=${unit} .value=${value}></dashboard-metric>`
 }


### PR DESCRIPTION
Due to the decorators used in the GUI code with lit which is not supported natively by node the tests under helper.test.js return module error. This commit fixes by refactoring the `simpleMetricFactory` method to remove dependency on code using experimental decorators.