### PR TITLE
Minor adjustment to the install script to allow retrying when npm fails

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -142,21 +142,23 @@ print "Installing Open Rowing Monitor, branch $BRANCH..."
 
 if ! [[ -d "${INSTALL_DIR}" ]]; then
   sudo mkdir -p $INSTALL_DIR
+
+  cd $INSTALL_DIR
+
+  # get project code from repository
+  sudo git init -q
+  # older versions of git would use 'master' instead of 'main' for the default branch
+  sudo git checkout -q -b $BRANCH
+  sudo git config remote.origin.url $GIT_REMOTE
+  sudo git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+  # prevent altering line endings
+  sudo git config core.autocrlf false
+  sudo git fetch --force origin
+  sudo git fetch --force --tags origin
+  sudo git reset --hard origin/$BRANCH
 fi
 
 cd $INSTALL_DIR
-
-# get project code from repository
-sudo git init -q
-# older versions of git would use 'master' instead of 'main' for the default branch
-sudo git checkout -q -b $BRANCH
-sudo git config remote.origin.url $GIT_REMOTE
-sudo git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
-# prevent altering line endings
-sudo git config core.autocrlf false
-sudo git fetch --force origin
-sudo git fetch --force --tags origin
-sudo git reset --hard origin/$BRANCH
 
 # add bin directory to the system path
 echo "export PATH=\"\$PATH:$INSTALL_DIR/bin\"" >> ~/.bashrc


### PR DESCRIPTION
When installing openrowingmonitor, I found that npm would sometimes time out when trying to download packages from the repository.  The install script didn't take account of this.

This small change allows the script to be rerun if it fails after the install directory is created and the git actions complete.  It's not especially efficient (it re-runs all the apt-get actions) and I don't know whether it's idempotent and fail-safe if one of the final stages (creating services) fails, but this change helped me get going so I though I'd suggest it.