### PR TITLE
make logging to file possible

### DIFF
--- a/config/default.config.js
+++ b/config/default.config.js
@@ -14,6 +14,7 @@
 import rowerProfiles from './rowerProfiles.js'
 
 export default {
+  logToFile: false,
   // Available log levels: trace, debug, info, warn, error, silent
   loglevel: {
     // The default log level

--- a/install/smb.conf
+++ b/install/smb.conf
@@ -48,3 +48,11 @@
    browseable = yes
    public = yes
    writable = yes
+
+[Logs]
+   comment = Open Rowing Monitor Logs
+   path = /opt/openrowingmonitor/logs
+   available = yes
+   browseable = yes
+   public = yes
+   writable = yes


### PR DESCRIPTION
Logging to a shared file makes it easier to setup the rower or find issues.