### PR TITLE
New GUI Tiles

### DIFF
--- a/app/client/store/appState.js
+++ b/app/client/store/appState.js
@@ -20,6 +20,7 @@ export const APP_STATE = {
     driveLength: 0,
     driveDuration: 0,
     driveHandleForceCurve: [],
+    drivePeakHandleForce: 0,
     driveDistance: 0,
     recoveryDuration: 0,
     dragFactor: undefined,

--- a/app/client/store/dashboardMetrics.js
+++ b/app/client/store/dashboardMetrics.js
@@ -95,7 +95,7 @@ export const DASHBOARD_METRICS = {
 
   forceCurve: { displayName: 'Force curve', size: 2, template: (metrics) => html`<dashboard-force-curve .updateForceCurve=${metrics.metricsContext?.isRecoveryStart} .value=${metrics?.driveHandleForceCurve} style="grid-column: span 2"></dashboard-force-curve>` },
 
-  peakForce: { displayName: 'Peak Force', size: 1, template: (metrics) => simpleMetricFactory(formatNumber(metrics?.drivePeakHandleForce), 'N', 'Force') },
+  peakForce: { displayName: 'Peak Force', size: 1, template: (metrics) => simpleMetricFactory(formatNumber(metrics?.drivePeakHandleForce), 'N', 'Peak Force') },
 
   strokeRatio: {
     displayName: 'Stroke Ratio',

--- a/app/client/store/dashboardMetrics.js
+++ b/app/client/store/dashboardMetrics.js
@@ -93,7 +93,9 @@ export const DASHBOARD_METRICS = {
 
   recoveryDuration: { displayName: 'Recovery duration', size: 1, template: (metrics, config) => simpleMetricFactory(formatNumber(metrics?.recoveryDuration, 2), 'sec', config?.guiConfigs?.showIcons ? 'Recovery' : '') },
 
-  forceCurve: { displayName: 'Force curve', size: 2, template: (metrics) => html`<dashboard-force-curve .updateForceCurve=${metrics.metricsContext?.isRecoveryStart} .value=${metrics?.driveHandleForceCurve} style="grid-column: span 2"></dashboard-force-curve>` }
+  forceCurve: { displayName: 'Force curve', size: 2, template: (metrics) => html`<dashboard-force-curve .updateForceCurve=${metrics.metricsContext?.isRecoveryStart} .value=${metrics?.driveHandleForceCurve} style="grid-column: span 2"></dashboard-force-curve>` },
+
+  peakForce: { displayName: 'Peak Force', size: 1, template: (metrics) => simpleMetricFactory(formatNumber(metrics?.drivePeakHandleForce), 'N', 'Force') }
 }
 
 /**

--- a/app/client/store/dashboardMetrics.js
+++ b/app/client/store/dashboardMetrics.js
@@ -95,7 +95,18 @@ export const DASHBOARD_METRICS = {
 
   forceCurve: { displayName: 'Force curve', size: 2, template: (metrics) => html`<dashboard-force-curve .updateForceCurve=${metrics.metricsContext?.isRecoveryStart} .value=${metrics?.driveHandleForceCurve} style="grid-column: span 2"></dashboard-force-curve>` },
 
-  peakForce: { displayName: 'Peak Force', size: 1, template: (metrics) => simpleMetricFactory(formatNumber(metrics?.drivePeakHandleForce), 'N', 'Force') }
+  peakForce: { displayName: 'Peak Force', size: 1, template: (metrics) => simpleMetricFactory(formatNumber(metrics?.drivePeakHandleForce), 'N', 'Force') },
+
+  strokeRatio: {
+    displayName: 'Stroke Ratio',
+    size: 1,
+    template: (metrics) => {
+      const ratio = metrics?.driveDuration && metrics?.recoveryDuration
+        ? `1:${(metrics.recoveryDuration / metrics.driveDuration).toFixed(1)}`
+        : undefined
+      return simpleMetricFactory(ratio, '', 'Ratio')
+    }
+  }
 }
 
 /**

--- a/app/client/store/dashboardMetrics.js
+++ b/app/client/store/dashboardMetrics.js
@@ -101,9 +101,17 @@ export const DASHBOARD_METRICS = {
     displayName: 'Stroke Ratio',
     size: 1,
     template: (metrics) => {
-      const ratio = metrics?.driveDuration && metrics?.recoveryDuration
-        ? `1:${(metrics.recoveryDuration / metrics.driveDuration).toFixed(1)}`
-        : undefined
+      // Check to make sure both values are truthy
+      // no 0, null, or undefined
+      const validRatio = metrics?.driveDuration && metrics?.recoveryDuration;
+      let ratio;
+
+      if (validRatio) {
+        ratio = `1:${(metrics.recoveryDuration / metrics.driveDuration).toFixed(1)}`
+      } else {
+        ratio = undefined;
+      }
+
       return simpleMetricFactory(ratio, '', 'Ratio')
     }
   }


### PR DESCRIPTION
First is the peak force metric, as described in #180 / #170 

Second is a new metric that came up in my club recently; thought it was an interesting metric that could replace 2 tiles with one for those interested in it: [Stroke ratio](https://rp3rowing.com/blog-items/whats-the-ideal-ratio-between-drive-time-and-recovery-time/). Lots of caveats there but something interesting to train for on the erg between water sessions.

<img width="1334" height="750" alt="localhost_(iPhone SE)" src="https://github.com/user-attachments/assets/b5e5756c-4471-46fb-952c-b01f9dab5dc3" />
