### PR TITLE
X Axis Indicators on Force Curve

### DIFF
--- a/app/client/components/DashboardForceCurve.js
+++ b/app/client/components/DashboardForceCurve.js
@@ -55,7 +55,7 @@ export class DashboardForceCurve extends AppElement {
   accessor _chart
 
   shouldUpdate () {
-    return this.updateForceCurve
+    return this._chart === undefined || this.updateForceCurve
   }
     
   willUpdate () {
@@ -130,7 +130,7 @@ export class DashboardForceCurve extends AppElement {
   render () {
     return html`
       <!== Only show label if no chart -->
-      ${this._chart && this._chart?.data.datasets[0].data.length ?
+      ${this._chart?.data.datasets[0].data.length ?
         '' :
         html`<div class="title"> Force Curve </div>`
       }

--- a/app/client/components/DashboardForceCurve.js
+++ b/app/client/components/DashboardForceCurve.js
@@ -18,7 +18,7 @@ const divisionLinesPlugin = {
     const { ctx, chartArea: { top, bottom } } = chart
     ctx.save()
     ctx.strokeStyle = 'rgba(255, 255, 255, 0.5)'
-    ctx.lineWidth = 3
+    ctx.lineWidth = 5
     ctx.setLineDash([5, 5])
     options.positions.forEach((xPos) => {
       const xPixel = chart.scales.x.getPixelForValue(xPos)
@@ -55,6 +55,7 @@ export class DashboardForceCurve extends AppElement {
     canvas {
       width: 100%;
       height: 100%;
+      cursor: pointer;
     }
   `
 
@@ -64,7 +65,7 @@ export class DashboardForceCurve extends AppElement {
   accessor updateForceCurve = false
 
   @property({
-    type: Array,
+    type: Array
   })
   accessor value = []
 
@@ -177,14 +178,12 @@ export class DashboardForceCurve extends AppElement {
 
   render () {
     return html`
-      <div @click=${this._handleClick} style="width: 100%; height: 100%;">
-        <!== Only show label if no chart -->
-        ${this._chart?.data.datasets[0].data.length ?
-          '' :
-          html`<div class="title"> Force Curve </div>`
-        }
-        <canvas id="chart"></canvas>
-      </div>
+      <!== Only show label if no chart -->
+      ${this._chart?.data.datasets[0].data.length ?
+        '' :
+        html`<div class="title"> Force Curve </div>`
+      }
+      <canvas @click="${this._handleClick}" id="chart"></canvas>
     `
   }
 }

--- a/app/client/components/DashboardForceCurve.js
+++ b/app/client/components/DashboardForceCurve.js
@@ -64,9 +64,15 @@ export class DashboardForceCurve extends AppElement {
   accessor updateForceCurve = false
 
   @property({
-    type: Array
+    type: Array,
   })
   accessor value = []
+
+  /** @type {0 | 2 | 3} */
+  @property({
+    type: Number
+  })
+  accessor divisionMode = 0
 
   @state()
   accessor _chart
@@ -75,24 +81,21 @@ export class DashboardForceCurve extends AppElement {
   @state()
   accessor _divisionMode = 0
 
-  shouldUpdate () {
-    return this._chart === undefined || this.updateForceCurve
+  shouldUpdate (changedProperties) {
+    return this.updateForceCurve || changedProperties.has('divisionMode') || this._chart === undefined
   }
 
   _handleClick () {
     const modes = /** @type {(0 | 2 | 3)[]} */ ([0, 2, 3])
-    this._divisionMode = modes[(modes.indexOf(this._divisionMode) + 1) % modes.length]
-    if (this._chart) {
-      this._updateDivisionLines()
-      this._chart.update()
-    }
+    const nextMode = modes[(modes.indexOf(this.divisionMode) + 1) % modes.length]
+    this.sendEvent('changeGuiSetting', { forceCurveDivisionMode: nextMode })
   }
 
   _updateDivisionLines () {
     if (!this._chart?.options?.plugins) { return }
     const dataLength = this.value?.length || 0
-    const positions = this._divisionMode > 0 && dataLength > 0 ?
-      Array.from({ length: this._divisionMode - 1 }, (_, i) => ((i + 1) * dataLength) / this._divisionMode) :
+    const positions = this.divisionMode > 0 && dataLength > 0 ?
+      Array.from({ length: this.divisionMode - 1 }, (_, i) => ((i + 1) * dataLength) / this.divisionMode) :
       []
     // @ts-ignore - divisionLines is a custom plugin not in Chart.js types
     this._chart.options.plugins.divisionLines.positions = positions
@@ -101,6 +104,7 @@ export class DashboardForceCurve extends AppElement {
   willUpdate () {
     if (this._chart?.data) {
       this._chart.data.datasets[0].data = this.value?.map((data, index) => ({ y: data, x: index }))
+      this._updateDivisionLines()
     }
   }
 

--- a/app/client/components/DashboardForceCurve.js
+++ b/app/client/components/DashboardForceCurve.js
@@ -10,6 +10,29 @@ import { customElement, property, state } from 'lit/decorators.js'
 import ChartDataLabels from 'chartjs-plugin-datalabels'
 import { Chart, Filler, Legend, LinearScale, LineController, LineElement, PointElement } from 'chart.js'
 
+/** @type {import('chart.js').Plugin<'line', {positions: number[]}>} */
+const divisionLinesPlugin = {
+  id: 'divisionLines',
+  afterDatasetsDraw (chart, args, options) {
+    if (!options.positions?.length) { return }
+    const { ctx, chartArea: { top, bottom } } = chart
+    ctx.save()
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.5)'
+    ctx.lineWidth = 3
+    ctx.setLineDash([5, 5])
+    options.positions.forEach((xPos) => {
+      const xPixel = chart.scales.x.getPixelForValue(xPos)
+      ctx.beginPath()
+      ctx.moveTo(xPixel, top)
+      ctx.lineTo(xPixel, bottom)
+      ctx.stroke()
+    })
+    ctx.restore()
+  }
+}
+
+Chart.register(ChartDataLabels, Legend, Filler, LinearScale, LineController, PointElement, LineElement, divisionLinesPlugin)
+
 @customElement('dashboard-force-curve')
 export class DashboardForceCurve extends AppElement {
   static styles = css`
@@ -35,37 +58,54 @@ export class DashboardForceCurve extends AppElement {
     }
   `
 
-  constructor () {
-    super()
-    Chart.register(ChartDataLabels, Legend, Filler, LinearScale, LineController, PointElement, LineElement)
-  }
-
   @property({
-    type: Boolean,
+    type: Boolean
   })
   accessor updateForceCurve = false
 
   @property({
-    type: Array,
+    type: Array
   })
   accessor value = []
-
 
   @state()
   accessor _chart
 
+  /** @type {0 | 2 | 3} */
+  @state()
+  accessor _divisionMode = 0
+
   shouldUpdate () {
     return this._chart === undefined || this.updateForceCurve
   }
-    
+
+  _handleClick () {
+    const modes = /** @type {(0 | 2 | 3)[]} */ ([0, 2, 3])
+    this._divisionMode = modes[(modes.indexOf(this._divisionMode) + 1) % modes.length]
+    if (this._chart) {
+      this._updateDivisionLines()
+      this._chart.update()
+    }
+  }
+
+  _updateDivisionLines () {
+    if (!this._chart?.options?.plugins) { return }
+    const dataLength = this.value?.length || 0
+    const positions = this._divisionMode > 0 && dataLength > 0 ?
+      Array.from({ length: this._divisionMode - 1 }, (_, i) => ((i + 1) * dataLength) / this._divisionMode) :
+      []
+    // @ts-ignore - divisionLines is a custom plugin not in Chart.js types
+    this._chart.options.plugins.divisionLines.positions = positions
+  }
+
   willUpdate () {
     if (this._chart?.data) {
       this._chart.data.datasets[0].data = this.value?.map((data, index) => ({ y: data, x: index }))
     }
   }
-  
+
   // Updated runs _after_ DOM elements exist, which is what chart.js expects.
-  updated() {
+  updated () {
     this._chart.update()
   }
 
@@ -95,6 +135,10 @@ export class DashboardForceCurve extends AppElement {
             },
             legend: {
               display: false
+            },
+            // @ts-ignore - divisionLines is a custom plugin not in Chart.js types
+            divisionLines: {
+              positions: []
             }
           },
           scales: {
@@ -129,12 +173,14 @@ export class DashboardForceCurve extends AppElement {
 
   render () {
     return html`
-      <!== Only show label if no chart -->
-      ${this._chart?.data.datasets[0].data.length ?
-        '' :
-        html`<div class="title"> Force Curve </div>`
-      }
-      <canvas id="chart"></canvas>
+      <div @click=${this._handleClick} style="width: 100%; height: 100%;">
+        <!== Only show label if no chart -->
+        ${this._chart?.data.datasets[0].data.length ?
+          '' :
+          html`<div class="title"> Force Curve </div>`
+        }
+        <canvas id="chart"></canvas>
+      </div>
     `
   }
 }

--- a/app/client/index.js
+++ b/app/client/index.js
@@ -60,16 +60,17 @@ export class App extends LitElement {
       Object.keys(event.detail).forEach((key) => {
         localStorage.setItem(key, JSON.stringify(event.detail[key]))
       })
+      const newGuiConfigs = {
+        ...this._appState.config.guiConfigs,
+        ...event.detail
+      }
       this.updateState({
         config: {
           ...this._appState.config,
-          guiConfigs: {
-            ...this._appState.config.guiConfigs,
-            ...event.detail
-          }
+          guiConfigs: newGuiConfigs
         }
       })
-      this.applyTheme(event.detail.trueBlackTheme)
+      this.applyTheme(newGuiConfigs.trueBlackTheme)
     })
   }
 

--- a/app/client/index.js
+++ b/app/client/index.js
@@ -60,7 +60,15 @@ export class App extends LitElement {
       Object.keys(event.detail).forEach((key) => {
         localStorage.setItem(key, JSON.stringify(event.detail[key]))
       })
-      this.updateState({ config: { ...this._appState.config, guiConfigs: { ...event.detail } } })
+      this.updateState({
+        config: {
+          ...this._appState.config,
+          guiConfigs: {
+            ...this._appState.config.guiConfigs,
+            ...event.detail
+          }
+        }
+      })
       this.applyTheme(event.detail.trueBlackTheme)
     })
   }

--- a/app/client/index.js
+++ b/app/client/index.js
@@ -8,6 +8,7 @@
 import { LitElement, html } from 'lit'
 import { customElement, state } from 'lit/decorators.js'
 import { APP_STATE } from './store/appState.js'
+import { DASHBOARD_METRICS } from './store/dashboardMetrics.js'
 import { createApp } from './lib/app.js'
 import './components/PerformanceDashboard.js'
 
@@ -32,14 +33,16 @@ export class App extends LitElement {
 
     const config = this._appState.config.guiConfigs
     Object.keys(config).forEach((key) => {
-      config[key] = JSON.parse(localStorage.getItem(key)) ?? config[key]
+      let savedValue = JSON.parse(localStorage.getItem(key))
+      
+      // Validate dashboardMetrics against known valid keys
+      if (key === 'dashboardMetrics' && Array.isArray(savedValue)) {
+        savedValue = savedValue.filter((metric) => DASHBOARD_METRICS[metric] !== undefined)
+      }
+      
+      config[key] = savedValue ?? config[key]
     })
 
-    // migrate: remove deprecated 'actions' metric from saved dashboardMetrics
-    if (config.dashboardMetrics.includes('actions')) {
-      config.dashboardMetrics = config.dashboardMetrics.filter((m) => m !== 'actions')
-      localStorage.setItem('dashboardMetrics', JSON.stringify(config.dashboardMetrics))
-    }
     // apply theme based on saved preference
     this.applyTheme(config.trueBlackTheme)
 
@@ -57,12 +60,19 @@ export class App extends LitElement {
 
     // notify the app about the triggered action
     this.addEventListener('changeGuiSetting', (event) => {
-      Object.keys(event.detail).forEach((key) => {
-        localStorage.setItem(key, JSON.stringify(event.detail[key]))
+      const detail = { ...event.detail }
+      
+      // Validate dashboardMetrics against known valid keys before saving
+      if (Array.isArray(detail.dashboardMetrics)) {
+        detail.dashboardMetrics = detail.dashboardMetrics.filter((metric) => DASHBOARD_METRICS[metric] !== undefined)
+      }
+
+      Object.keys(detail).forEach((key) => {
+        localStorage.setItem(key, JSON.stringify(detail[key]))
       })
       const newGuiConfigs = {
         ...this._appState.config.guiConfigs,
-        ...event.detail
+        ...detail
       }
       this.updateState({
         config: {

--- a/app/client/store/appState.js
+++ b/app/client/store/appState.js
@@ -51,7 +51,8 @@ export const APP_STATE = {
       dashboardMetrics: ['distance', 'timer', 'pace', 'power', 'stkRate', 'totalStk', 'calories'],
       showIcons: true,
       maxNumberOfTiles: 8,
-      trueBlackTheme: false
+      trueBlackTheme: false,
+      forceCurveDivisionMode: 0
     }
   }
 }

--- a/app/client/store/dashboardMetrics.js
+++ b/app/client/store/dashboardMetrics.js
@@ -93,7 +93,14 @@ export const DASHBOARD_METRICS = {
 
   recoveryDuration: { displayName: 'Recovery duration', size: 1, template: (metrics, config) => simpleMetricFactory(formatNumber(metrics?.recoveryDuration, 2), 'sec', config?.guiConfigs?.showIcons ? 'Recovery' : '') },
 
-  forceCurve: { displayName: 'Force curve', size: 2, template: (metrics) => html`<dashboard-force-curve .updateForceCurve=${metrics.metricsContext?.isRecoveryStart} .value=${metrics?.driveHandleForceCurve} style="grid-column: span 2"></dashboard-force-curve>` },
+  forceCurve: { displayName: 'Force curve', size: 2, template: (metrics, config) => html`
+    <dashboard-force-curve 
+      .updateForceCurve=${metrics.metricsContext?.isRecoveryStart} 
+      .value=${metrics?.driveHandleForceCurve} 
+      .divisionMode=${config?.guiConfigs?.forceCurveDivisionMode ?? 0} 
+      style="grid-column: span 2"
+    ></dashboard-force-curve>
+  ` },
 
   peakForce: { displayName: 'Peak Force', size: 1, template: (metrics) => simpleMetricFactory(formatNumber(metrics?.drivePeakHandleForce), 'N', 'Peak Force') },
 


### PR DESCRIPTION
Initially thought of this in #170 

One of the downsides of [this decision](https://github.com/JaapvanEkris/openrowingmonitor/pull/170#issuecomment-3858600469)
> … keep the (y) axis.

Was the loss of [this bit](https://github.com/JaapvanEkris/openrowingmonitor/pull/170#issuecomment-3858369454) of "built in" force curve measuring; because of the grid layout and the fact that force curve spans 2 normal tiles, having 2 tiles above or below provided a natural "50%" line to base the shape off of.

So I was thinking… what if we just marked the halfway point manually?

And was then encouraged by this line in [this comment](https://github.com/JaapvanEkris/openrowingmonitor/pull/170#issuecomment-3859352967):
> … and show what the peak is in percentage on the x-axis as well.

Not much room for numerical percentage. But a line? Easy to see throughout the stroke, or at least the catch.

So: tap to add a halfway marker. 

Checking my assumptions, [I found out about some of the other common issues](http://www.concept2.tw/en/indoor-rowers/training/tips-and-general-info/using-the-force-curve); multi-peak/valley, sharp spikes that folks might want to monitor. So I added thirds as well.

Not biomechanically accurate (leg, hip, arm drive are not all same length), but could be a handy diagnostic.

So: second tap for thirds.

Tap again to reset to clear.

Some screencaps:
<img width="1334" height="750" alt="force curve with halves indicated" src="https://github.com/user-attachments/assets/f263e59a-20d9-4a7c-85f5-21987ab2df69" />

<img width="1334" height="750" alt="force curve with thirds indicated" src="https://github.com/user-attachments/assets/1fe0362f-7d0c-4ca0-a239-70915cf8fdcb" />

Linter was complaining about types, hints, etc. So, knowing about the intended TS converesion, I figured I'd add some hints to at least get the warnings/errors cleared on this file.

What do y'all think?