### PR TITLE
Bugfix for array overflow

### DIFF
--- a/app/recorders/fitRecorder.js
+++ b/app/recorders/fitRecorder.js
@@ -1471,9 +1471,9 @@ export function createFITRecorder (config) {
       developerFieldValues.push({ developer_data_index: 0, field_num: 17, value: trackpoint.drivePeakHandleForceNormalizedPosition * 100 })
     }
 
-    if (trackpoint.forceCurve.length > 0 && trackpoint.forceCurve.length < 128) {
+    if (trackpoint.forceCurve.length > 0 && trackpoint.forceCurve.length < Math.min(127, sessionData.maxForceCurvePointCount)) {
       const sampleInterval = trackpoint.driveLength / trackpoint.forceCurve.length
-      const paddedForceCurve = Array.from({ length: sessionData.maxForceCurvePointCount }, (_, i) => trackpoint.forceCurve[i] ?? '0')
+      const paddedForceCurve = Array.from({ length: Math.min(127, sessionData.maxForceCurvePointCount) }, (_, i) => trackpoint.forceCurve[i] ?? '0')
       developerFieldValues.push({ developer_data_index: 0, field_num: 90, value: 2 })
       developerFieldValues.push({ developer_data_index: 0, field_num: 91, value: sampleInterval * 10000 })
       developerFieldValues.push({ developer_data_index: 0, field_num: 92, value: trackpoint.forceCurve.length })

--- a/app/recorders/fitRecorder.js
+++ b/app/recorders/fitRecorder.js
@@ -1471,7 +1471,7 @@ export function createFITRecorder (config) {
       developerFieldValues.push({ developer_data_index: 0, field_num: 17, value: trackpoint.drivePeakHandleForceNormalizedPosition * 100 })
     }
 
-    if (trackpoint.forceCurve.length > 0 && trackpoint.forceCurve.length < Math.min(127, sessionData.maxForceCurvePointCount)) {
+    if (trackpoint.forceCurve.length > 0 && trackpoint.forceCurve.length <= Math.min(127, sessionData.maxForceCurvePointCount)) {
       const sampleInterval = trackpoint.driveLength / trackpoint.forceCurve.length
       const paddedForceCurve = Array.from({ length: Math.min(127, sessionData.maxForceCurvePointCount) }, (_, i) => trackpoint.forceCurve[i] ?? '0')
       developerFieldValues.push({ developer_data_index: 0, field_num: 90, value: 2 })


### PR DESCRIPTION
Fix for not cutting off force curves with more than 127 datapoints, resulting in a nasty uncontrolled crash of FIT-filewriter.

Skips forcecurves with more than 127 datapoints.